### PR TITLE
Update to work with new GitHub Actions

### DIFF
--- a/.github/workflows/FileList.yml
+++ b/.github/workflows/FileList.yml
@@ -5,16 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DotMod Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: main
-          token: ${{ secrets.ORG_ACCESS_TOKEN }}
       - name: Checkout DotMod Website Repo
-        uses:  actions/checkout@v2
+        uses:  actions/checkout@v4
         with:
           path: website
           repository: DotModGroup/DotModGroup.github.io
-          token: ${{ secrets.ORG_ACCESS_TOKEN }}
       - name: Build Weapon Data Table
         shell: pwsh
         run: |


### PR DESCRIPTION
Update to latest version of checkout

Remove explicit tokens.  It will use the default GITHUB_TOKEN